### PR TITLE
GPII-3348: Move gpii-grunt-lint-all to dev dependency block.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,10 +27,10 @@ module.exports = function (grunt) {
     grunt.initConfig({
         lintAll: {
             sources: {
-                md: ["./*.md", "./**/*.md", "!./node_modules/**", "!./tests/markdown/bad*"],
-                js: [ "./tasks/**/*.js", "./src/**/*.js", "./tests/**/*.js","./*.js" ],
-                json: ["./src/**/*.json", "tests/**/*.json", "./*.json", "!./tests/markdown/bad*"],
-                json5: ["./src/**/*.json5", "tests/**/*.json5", "./*.json5", "!./tests/markdown/bad*"],
+                md:    ["*.md", "!./node_modules/**", "!./tests/markdown/bad*"],
+                js:    ["*.js"],
+                json:  ["*.json", "!./tests/markdown/bad*"],
+                json5: ["*.json5", "!./tests/markdown/bad*"],
                 other: ["./.*"]
             }
         }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
         "test": "node node_modules/istanbul/lib/cli.js cover tests/all-tests.js"
     },
     "dependencies": {
-        "gpii-grunt-lint-all": "1.0.1-dev.20180706T153657Z.4cbbd61",
         "infusion": "3.0.0-dev.20171006T195039Z.a128358",
         "json5": "1.0.1",
         "@textlint/markdown-to-ast": "6.0.9"
@@ -23,6 +22,7 @@
     "devDependencies": {
         "eslint": "5.2.0",
         "eslint-config-fluid": "1.3.0",
+        "gpii-grunt-lint-all": "1.0.1-dev.20180706T153657Z.4cbbd61",
         "grunt": "1.0.3",
         "grunt-markdownlint": "2.1.0",
         "istanbul": "0.4.5",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "devDependencies": {
         "eslint": "5.2.0",
         "eslint-config-fluid": "1.3.0",
-        "gpii-grunt-lint-all": "1.0.1-dev.20180706T153657Z.4cbbd61",
+        "gpii-grunt-lint-all": "1.0.5-dev.20180913T111528Z.0b48f94",
         "grunt": "1.0.3",
         "grunt-markdownlint": "2.1.0",
         "istanbul": "0.4.5",


### PR DESCRIPTION
See [GPII-3348](https://issues.gpii.net/browse/GPII-3348) for details.